### PR TITLE
Permissions added are described in the comments

### DIFF
--- a/src/server/domain/Jobs/FounderRole.ts
+++ b/src/server/domain/Jobs/FounderRole.ts
@@ -11,9 +11,10 @@ export class FounderRole extends Role {
     this.permissions.push("AddProduct");
     this.permissions.push("EditProductDetails");
     this.permissions.push("RemoveProduct");
-    this.permissions.push("SeeStoreData");
+    this.permissions.push("receivePrivateStoreData");
     this.permissions.push("AppointStoreOwner");
     this.permissions.push("AppointStoreManager");
+    this.permissions.push("receiveClosedStoreData");
   }
   grantPermission(permission: EditablePermission): void {
     throw new TRPCError({

--- a/src/server/domain/Jobs/ManagerRole.ts
+++ b/src/server/domain/Jobs/ManagerRole.ts
@@ -4,7 +4,7 @@ import { Role, Permission, type EditablePermission } from "./Role";
 export class ManagerRole extends Role {
   constructor() {
     super();
-    this.permissions.push("SeeStoreData");
+    this.permissions.push("receivePrivateStoreData");
     this.roleType = "Manager";
   }
   grantPermission(permission: EditablePermission): void {

--- a/src/server/domain/Jobs/OwnerRole.ts
+++ b/src/server/domain/Jobs/OwnerRole.ts
@@ -8,9 +8,10 @@ export class OwnerRole extends Role {
     this.permissions.push("AddProduct");
     this.permissions.push("EditProductDetails");
     this.permissions.push("RemoveProduct");
-    this.permissions.push("SeeStoreData");
+    this.permissions.push("receivePrivateStoreData");
     this.permissions.push("AppointStoreOwner");
     this.permissions.push("AppointStoreManager");
+    this.permissions.push("receiveClosedStoreData");
   }
   grantPermission(permission: EditablePermission): void {
     throw new TRPCError({

--- a/src/server/domain/Jobs/Role.ts
+++ b/src/server/domain/Jobs/Role.ts
@@ -3,12 +3,13 @@ export type Permission =
   | "ActivateStore"
   | EditablePermission
   | "AppointStoreOwner"
-  | "AppointStoreManager";
+  | "AppointStoreManager"
+  | "receiveClosedStoreData";
 export type EditablePermission =
   | "AddProduct"
   | "EditProductDetails"
   | "RemoveProduct"
-  | "SeeStoreData";
+  | "receivePrivateStoreData";
 export type RoleType = "Owner" | "Manager" | "Founder";
 export abstract class Role {
   protected permissions: Permission[];

--- a/src/server/domain/Stores/StoresController.test.ts
+++ b/src/server/domain/Stores/StoresController.test.ts
@@ -37,13 +37,19 @@ describe("search products", () => {
   });
 
   it("✅should return all products", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {});
     expect(res).toEqual(products.map((p) => p.DTO));
   });
 
   it("✅should return some products because of name filter", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       name: products[0]?.Name.toUpperCase().split(" ")[0],
     });
@@ -51,7 +57,10 @@ describe("search products", () => {
   });
 
   it("✅should return some products because of keywords", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       keywords: [products[1]?.Description.toUpperCase().split(" ")[1] ?? ""],
     });
@@ -59,7 +68,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of made up name", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       name: "made up name that doesn't exist",
     });
@@ -67,7 +79,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of made up category", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       category: "made up category that doesn't exist",
     });
@@ -75,7 +90,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of made up keywords", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       keywords: ["made up keyword that doesn't exist"],
     });
@@ -83,7 +101,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of high min price", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       minPrice: Infinity,
     });
@@ -91,7 +112,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of low max price", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       maxPrice: 0,
     });
@@ -99,7 +123,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of high min store rating", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       minStoreRating: Infinity,
     });
@@ -107,7 +134,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of low max store rating", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       maxStoreRating: 0,
     });
@@ -115,7 +145,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of high min product rating", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       minProductRating: Infinity,
     });
@@ -123,7 +156,10 @@ describe("search products", () => {
   });
 
   it("✅shouldn't return products because of low max product rating", () => {
-    vi.spyOn(controllers.Jobs, "canReceiveDataFromStore").mockReturnValue(true);
+    vi.spyOn(
+      controllers.Jobs,
+      "canReceivePrivateDataFromStore"
+    ).mockReturnValue(true);
     const res = controllers.Stores.searchProducts("uid", {
       maxProductRating: 0,
     });

--- a/src/server/domain/Stores/StoresController.ts
+++ b/src/server/domain/Stores/StoresController.ts
@@ -242,7 +242,7 @@ export class StoresController
   searchProducts(userId: string, args: SearchArgs): StoreProductDTO[] {
     return StoreProduct.getAll(this.Repos)
       .filter((p) =>
-        this.Controllers.Jobs.canReceiveDataFromStore(userId, p.Store.Id)
+        this.Controllers.Jobs.canReceivePrivateDataFromStore(userId, p.Store.Id)
       )
       .filter((p) => {
         const productRating =
@@ -322,7 +322,7 @@ export class StoresController
   }
 
   isStoreActive(userId: string, storeId: string): boolean {
-    this.checkDataRetrievalPermission(userId, storeId);
+    // this.checkDataRetrievalPermission(userId, storeId);
     return Store.fromStoreId(storeId, this.Repos).IsActive;
   }
 
@@ -332,7 +332,9 @@ export class StoresController
   }
 
   private checkDataRetrievalPermission(userId: string, storeId: string) {
-    if (!this.Controllers.Jobs.canReceiveDataFromStore(userId, storeId)) {
+    if (
+      !this.Controllers.Jobs.canReceivePrivateDataFromStore(userId, storeId)
+    ) {
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "User does not have permission to receive data from store",

--- a/src/server/domain/Users/UserController.test.ts
+++ b/src/server/domain/Users/UserController.test.ts
@@ -396,7 +396,6 @@ describe("remove member", () => {
     const AdminId = controllers.Auth.register("admin", "admin");
     controllers.Jobs.setInitialAdmin(AdminId);
     expect(true).toBe(true);
-    //TODO: @ilaytzarfati1231 why does the line below crash?
     const guestId = controllers.Users.startSession();
     controllers.Users.register(email, password);
     //log the user in then check if the user exists, then remove the user and check if the user exists


### PR DESCRIPTION
canReceiveStorePublicData()- for general usage of customers (will return false only if the store is closed)

canReceiveStorePrivateData()- a rename for the current canReceiveDataFromStore.(however this will now return false for managers if store is closed). *There is also a canReceivePurchaseHistoryFromStore() function.